### PR TITLE
Radars have a numeric id. Remove radarData from model.

### DIFF
--- a/scripts/mongo/schema/init.js
+++ b/scripts/mongo/schema/init.js
@@ -2,6 +2,7 @@ const conn = new Mongo()
 const db = conn.getDB('swforum-radar')
 
 db.sequences.insert({ _id: 'project', seq: 0 })
+db.sequences.insert({ _id: 'radar', seq: 0 })
 
 db.users.insert({
     name: 'admin',

--- a/src/server/controllers/radar-populate/radarPopulation.js
+++ b/src/server/controllers/radar-populate/radarPopulation.js
@@ -108,26 +108,25 @@ const calculateRing = (project, radarDate) => {
 //
 // transform the ugly data "structure" into a RadarData entity (just as ugly)
 const createRadarData = (data) => {
-    const radarData = new RadarData({})
-    radarData.data = new Map()
+    const radarData = new Map()
     for (const [segKey, segMap] of data.entries()) {
         const segDataMap = new Map()
         for (const [ringKey, entries] of segMap.entries()) {
             const stats = calculateStatistics(entries)
             const ringData = []
-            entries.forEach((e) => {
-                const blip = new Blip({
-                    project: e.prj._id,
-                    tags: e.prj.tags,
-                    cw_id: e.prj.cw_id, // temporary
-                    prj_acronym: e.prj.acronym, // temporary
+            entries.forEach((entry) => {
+                const blip = {
+                    project: entry.prj._id,
+                    tags: entry.prj.tags,
+                    cw_id: entry.prj.cw_id, // temporary
+                    prj_acronym: entry.prj.acronym, // temporary
                     segment: segKey, // temporary
                     ring: ringKey, // temporary
-                })
-                if (e.score) {
-                    blip.trl = e.score.trl
-                    blip.mrl = e.score.mrl
-                    blip.score = e.score.score
+                }
+                if (entry.score) {
+                    blip.trl = entry.score.trl
+                    blip.mrl = entry.score.mrl
+                    blip.score = entry.score.score
                     blip.median = stats.median
                     blip.performance = blip.score - blip.median
                     blip.min = stats.min
@@ -137,7 +136,7 @@ const createRadarData = (data) => {
             })
             segDataMap.set(ringKey, ringData)
         }
-        radarData.data.set(segKey, segDataMap)
+        radarData.set(segKey, segDataMap)
     }
 
     return radarData

--- a/src/server/controllers/radar-render/renderer.js
+++ b/src/server/controllers/radar-render/renderer.js
@@ -42,12 +42,12 @@ const plotRadar = (root, data) => {
     // 1) calculate some base values
     // 56 = width of segment name, 2 = thickness of ring stroke
     const radius = (size - 2) / 2 - 56
-    const numSegs = data.data.size
-    const numRings = data.data.values().next().value.size
+    const numSegs = data.size
+    const numRings = data.values().next().value.size
     const angles = calcAngles(numSegs)
     const radii = equiSpatialRadii(numSegs, numRings, radius)
 
-    plotSegments(root, data.data, angles, radii)
+    plotSegments(root, data, angles, radii)
 }
 
 // plot each segment

--- a/src/server/models/radarDataModel.js
+++ b/src/server/models/radarDataModel.js
@@ -8,49 +8,6 @@ const mongoose = require('mongoose')
 //
 // SCHEMAS
 //
-// individual project blips for a radar
-const blipSchema = new mongoose.Schema({
-    project: {
-        type: mongoose.Schema.ObjectId,
-        ref: 'Project',
-        required: [true, 'Radar blip entry must have a project reference'],
-    },
-    tags: [String],
-    cw_id: Number, // temporary
-    prj_acronym: String, // temporary
-    segment: String, // temporary
-    ring: String, // temporary
-    trl: Number,
-    mrl: Number,
-    score: Number,
-    median: Number,
-    performance: Number,
-    min: Number,
-    max: Number,
-})
-// the complete collection of radar data, ready to be rendered into an SVG
-// and corresponding overview tables
-const radarDataSchema = new mongoose.Schema(
-    {
-        radar: {
-            type: mongoose.Schema.ObjectId,
-            ref: 'Radar',
-            required: [true, 'A RadarData document must be linked to exactly one Radar instance'],
-        },
-        data: {
-            type: Map, // segment --> Map
-            of: {
-                type: Map, // ring --> Array[blips]
-                of: [blipSchema],
-            },
-        },
-    },
-    {
-        toJSON: { virtuals: true },
-        toObject: { virtuals: true },
-    }
-)
-// the scema for the radar renderings
 const radarRenderingSchema = new mongoose.Schema(
     {
         radar: {
@@ -73,14 +30,10 @@ const radarRenderingSchema = new mongoose.Schema(
 //
 // MODELS
 //
-// individual blips
-const Blip = mongoose.model('Blip', blipSchema)
-// the collection of blips in a radar's data population
-const RadarData = mongoose.model('RadarData', radarDataSchema)
 // the finished rendering of a radar
 const RadarRendering = mongoose.model('RadarRendering', radarRenderingSchema)
 
 //
 // EXPORTS
 //
-module.exports = { Blip, RadarData, RadarRendering }
+module.exports = { RadarRendering }


### PR DESCRIPTION
Two refactorings in one:
- Radars now have numerical ids. (They are just not used yet)
- radarData (the data structure that dfines which projects are included in the radar, and in which segment and ring they are placed) has been removed from the model and all associated data structures.